### PR TITLE
Use MutationObserver to trigger emote replacement

### DIFF
--- a/RumbleChatEmotes.js
+++ b/RumbleChatEmotes.js
@@ -171,8 +171,8 @@
     };
 
     const observer = new MutationObserver(mutationList => {
-        for (mutation of mutationList) {
-            for (node of mutation.addedNodes) {
+        for (const mutation of mutationList) {
+            for (const node of mutation.addedNodes) {
                 let messageElem;
 
                 if (node.matches('.chat-history--rant')) {


### PR DESCRIPTION
What do you think about this approach?

This replaces the usage of `setInterval(() => …, 500)` to trigger emote replacement with a [`MutationObserver`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver).

The `MutationObserver` will call the given callback every time a child element is added to `#chat-history-list`. By iterating over `mutation.addedNodes` we can access references to new messages directly instead of requerying them from the DOM.