### PR TITLE
Fix disabled chat send button

### DIFF
--- a/RumbleChatEmotes.js
+++ b/RumbleChatEmotes.js
@@ -64,6 +64,7 @@
       document.querySelector('.RumbleChatEmotes-emoteMenu').addEventListener('click', (ev) => {
         if (!ev.target.matches('img')) return;
         document.querySelector('.chat--input').value += ev.target.title;
+        document.querySelector('.chat--send').disabled = false;
       });
     });
 


### PR DESCRIPTION
When adding an emote from the emote menu the Send Message button is disabled. This fixes that.